### PR TITLE
受け入れテスト指摘対応(ユーザ登録画面)

### DIFF
--- a/src/main/java/jp/co/example/ecommerce_c/controller/RegisterUserController.java
+++ b/src/main/java/jp/co/example/ecommerce_c/controller/RegisterUserController.java
@@ -44,7 +44,6 @@ public class RegisterUserController {
 	public String registerUser(@Validated RegisterUserForm form, BindingResult result) {
 		// パスワード確認
 		if (!(form.getConfirmPassword().equals(form.getPassword()))) {
-			result.rejectValue("password", "", "パスワードと確認用パスワードが不一致です。");
 			result.rejectValue("confirmPassword", "", "パスワードと確認用パスワードが不一致です。");
 		}
 

--- a/src/main/resources/templates/register_user.html
+++ b/src/main/resources/templates/register_user.html
@@ -59,27 +59,27 @@
 								<label for="inputName">名前:</label><label
 									class="control-label" style="color: red" for="inputError" th:errors="*{name}">名前を入力してください</label>
 								<input type="text" id="inputName" class="form-control"
-									placeholder="Name" th:field="*{name}">
+									placeholder="名無し太郎" th:field="*{name}">
 							</div>
 							<div class="form-group">
 								<label for="inputEmail">メールアドレス:</label><label
 									class="control-label" style="color: red" for="inputError" th:errors="*{email}">メールアドレスを入力してください</label>
 								<input type="text" id="inputEmail" class="form-control"
-									placeholder="Email" th:field="*{email}">
+									placeholder="sample@sample.com" th:field="*{email}">
 							</div>
 							<div class="form-group">
 								<label for="zipCode">郵便番号（ハイフン含む）:</label>
 								<label
 									class="control-label" style="color: red" for="inputError" th:errors="*{zipcode}">郵便番号を入力してください</label>
 									
-									<input id="zipcode" name="zipcode" type="text" size="8" placeholder="Zipcode" />
+									<input id="zipcode" name="zipcode" type="text" size="8" placeholder="XXX-XXXX" th:field="*{zipcode}"/>
 									<button type="button" onClick="AjaxZip3.zip2addr('zipcode', '', 'address', 'address');">住所検索</button><br>
 									
 								<label for="address">住所:</label>
 								<label
 									class="control-label" style="color: red" for="inputError" th:errors="*{address}">住所を入力してください</label>
 									<input type="text" id="address" class="form-control" name="address"
-									placeholder="Address" th:field="*{address}">
+									placeholder="住所" th:field="*{address}">
 									
 							</div>
 							
@@ -88,21 +88,21 @@
 								<label
 									class="control-label" style="color: red" for="inputError" th:errors="*{telephone}">電話番号を入力してください</label>
 								<input type="text" id="inputTel" class="form-control"
-									placeholder="Tel" th:field="*{telephone}">
+									placeholder="XXXX-XXXX-XXXX" th:field="*{telephone}">
 							</div>
 							<div class="form-group">
 								<label for="inputPassword">パスワード:</label>
 								<label
 									class="control-label" style="color: red" for="inputError" th:errors="*{password}">パスワードを入力してください</label>
 								<input type="password" id="inputPassword" class="form-control"
-									placeholder="パスワード" th:field="*{password}">
+									placeholder="パスワード(８文字以上１６文字以内)" th:field="*{password}">
 							</div>
 							<div class="form-group">
 								<label for="inputConfirmationPassword">確認用パスワード:</label>
 								<label
 									class="control-label" style="color: red" for="inputError" th:errors="*{confirmPassword}">確認用パスワードを入力してください</label>
 								<input type="password" id="inputConfirmationPassword" class="form-control"
-									placeholder="確認用パスワード" th:field="*{confirmPassword}">
+									placeholder="確認用パスワード(８文字以上１６文字以内)" th:field="*{confirmPassword}">
 							</div>
 							<div class="form-group">
 								<button type="submit" class="btn btn-primary">登録</button>


### PR DESCRIPTION
修正箇所 
・ (高)エラー時に郵便番号を残す
・(高)電話番号の形式は黒字で最初に表示させる
・(高)エラー時にパスワード欄に表示される「不一致」のメッセージを削除